### PR TITLE
Add go_script gem; update guides_style_18f, titles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'rouge'
+gem 'go_script'
 
 group :jekyll_plugins do
   gem 'guides_style_18f'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,10 @@ GEM
     execjs (2.5.2)
     fast-stemmer (1.0.2)
     ffi (1.9.9)
-    guides_style_18f (0.0.0)
+    go_script (0.1.4)
+      bundler (~> 1.10)
+      safe_yaml (~> 1.0)
+    guides_style_18f (0.1.1)
       jekyll (~> 2.5)
       rouge (~> 1.9)
       sass (~> 3.4)
@@ -72,6 +75,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  go_script
   guides_style_18f
   jekyll
   rouge

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,3 @@
-baseurl: /federalist-content-guide
 markdown: redcarpet
 name: A content guide for the Federalist platform
 exclude:
@@ -11,6 +10,9 @@ exclude:
 
 permalink: pretty
 highlighter: rouge
+
+sass:
+  style: :compressed
 
 # Author/Organization info to be displayed in the templates
 author:
@@ -48,14 +50,7 @@ repos:
   description: Main repository
   url: https://github.com/18F/federalist-content-guide
 
-# Style Variables
-brand_color: "#1188ff"
-
 google_analytics_ua: UA-48605964-19
-
-# To use the shared 18F Guides styles when deploying to pages.18f.gov,
-# uncomment the following; comment it out during local development:
-asset_root: /guides-template
 
 back_link:
   url: "https://pages.18f.gov/guides/"

--- a/go
+++ b/go
@@ -1,141 +1,54 @@
 #! /usr/bin/env ruby
-#
-# 18F Guides Jekyll template
-#
-# Written in 2015 by Mike Bland (michael.bland@gsa.gov)
-# on behalf of the 18F team, part of the US General Services Administration:
-# https://18f.gsa.gov/
-#
-# To the extent possible under law, the author(s) have dedicated all copyright
-# and related and neighboring rights to this software to the public domain
-# worldwide. This software is distributed without any warranty.
-#
-# You should have received a copy of the CC0 Public Domain Dedication along
-# with this software. If not, see
-# <https://creativecommons.org/publicdomain/zero/1.0/>.
-#
-# @author Mike Bland (michael.bland@gsa.gov)
-#
-# ----
-#
-# ./go script: unified development environment interface
-#
-# Inspired by:
-# http://www.thoughtworks.com/insights/blog/praise-go-script-part-i
-# http://www.thoughtworks.com/insights/blog/praise-go-script-part-ii
-#
-# Author: Mike Bland (michael.bland@gsa.gov)
-# Date:   2015-04-15
 
-MIN_VERSION = "2.1.5"
+require 'English'
 
-unless RUBY_VERSION >= MIN_VERSION
-  puts <<EOF
+Dir.chdir File.dirname(__FILE__)
 
-*** ABORTING: Unsupported Ruby version ***
-
-Ruby version #{MIN_VERSION} or greater is required to work with the Hub, but
-this Ruby is version #{RUBY_VERSION}. Consider using a version manager such as
-rbenv (https://github.com/sstephenson/rbenv) or rvm (https://rvm.io/)
-to install a Ruby version specifically for Hub development.
-
-EOF
-  exit 1
+def try_command_and_restart(command)
+  exit $CHILD_STATUS.exitstatus unless system command
+  exec RbConfig.ruby, *[$PROGRAM_NAME].concat(ARGV)
 end
 
-def exec_cmd(cmd)
-  exit $?.exitstatus unless system(cmd)
+begin
+  require 'bundler/setup' if File.exist? 'Gemfile'
+rescue LoadError
+  try_command_and_restart 'gem install bundler'
+rescue SystemExit
+  try_command_and_restart 'bundle install'
 end
 
-def init
-  begin
-    require 'bundler'
-  rescue LoadError
-    puts "Installing Bundler gem..."
-    exec_cmd 'gem install bundler'
-    puts "Bundler installed; installing gems"
-  end
-  exec_cmd 'bundle install'
+begin
+  require 'go_script'
+rescue LoadError
+  try_command_and_restart 'gem install go_script' unless File.exist? 'Gemfile'
+  abort "Please add \"gem 'go_script'\" to your Gemfile"
 end
 
-def update_gems
-  exec_cmd 'bundle update'
-  exec_cmd 'git add Gemfile.lock'
+require 'guides_style_18f'
+
+extend GoScript
+check_ruby_version '2.1.5'
+
+command_group :dev, 'Development commands'
+
+def_command :update_nav, 'Update the \'navigation:\' data in _config.yml' do
+  GuidesStyle18F.update_navigation_configuration Dir.pwd
 end
 
-JEKYLL_BUILD_CMD = "exec jekyll build --trace"
-JEKYLL_SERVE_CMD = "exec jekyll serve --trace"
-
-def serve
-  exec "bundle #{JEKYLL_SERVE_CMD}"
+def_command :update_theme, 'Update the guides_style_18f gem' do
+  exec_cmd 'bundle update --source guides_style_18f'
 end
 
-def build
-  exec_cmd "bundle #{JEKYLL_BUILD_CMD}"
+def_command :update_gems, 'Update Ruby gems' do |gems|
+  update_gems gems
 end
 
-# Groups a set of commands by common function.
-class CommandGroup
-  attr_accessor :description, :commands
-  private_class_method :new
-  @@groups = Array.new
-
-  # @param description [String] short description of the group
-  # @param commands [Hash<Symbol,String>] mapping from command function name
-  #   to a brief description; each key must be the name of a function in this
-  #   script
-  def initialize(description, commands)
-    @description = description
-    @commands = commands
-  end
-
-  def to_s
-    padding = @commands.keys.max_by {|i| i.size}.size + 2
-    ["\n#{@description}"].concat(
-      @commands.map {|name, desc| "  %-#{padding}s#{desc}" % name}).join("\n")
-  end
-
-  def self.add_group(description, commands)
-    @@groups << new(description, commands)
-  end
-
-  def self.groups
-    @@groups
-  end
-
-  def self.check_command_exists(command_symbol)
-    all_commands = @@groups.map {|i| i.commands.keys}.flatten
-    unless all_commands.member? command_symbol
-      puts "Unknown option or command: #{command_symbol}"
-      usage(exitstatus: 1)
-    end
-  end
+def_command :serve, 'Serve the site at localhost:4000' do
+  serve_jekyll
 end
 
-CommandGroup.add_group(
-  'Development commands',
-  {
-    :init => 'Set up the dev environment',
-    :update_gems => 'Execute Bundler to update gem set',
-    :serve => 'Serves the site at localhost:4000',
-    :build => 'Builds the site',
-  })
-
-def usage(exitstatus: 0)
-  puts <<EOF
-Usage: #{$0} [options] [command]
-
-options:
-  -h,--help  Show this help
-EOF
-  CommandGroup.groups.each {|s| puts s}
-  exit exitstatus
+def_command :build, 'Build the site' do
+  build_jekyll
 end
 
-usage(exitstatus: 1) unless ARGV.size == 1
-command = ARGV.shift
-usage if ['-h', '--help'].include? command
-
-command = command.to_sym
-CommandGroup.check_command_exists command
-send command
+execute_command ARGV

--- a/pages/best-practices-for-writing-about-your-research.md
+++ b/pages/best-practices-for-writing-about-your-research.md
@@ -1,6 +1,6 @@
 ---
 permalink: /writing-what-we-do/
-title: Best practices for writing about your research
+title: Writing about your research
 ---
 
 Writing about your research for a lay audience can be challenging. It helps to break your research down into the following questions:

--- a/pages/best-practices-for-writing-about-yourselves.md
+++ b/pages/best-practices-for-writing-about-yourselves.md
@@ -1,6 +1,6 @@
 ---
 permalink: /writing-who-we-are/
-title: Best practices for writing about yourselves
+title: Writing about your team
 ---
 
 The About section of your website should state what your team does in a clear and user-friendly way.

--- a/pages/contact-forms.md
+++ b/pages/contact-forms.md
@@ -1,6 +1,6 @@
 ---
 permalink: /contact-forms/
-title: Best practices for writing contact forms
+title: Writing clear contact forms
 ---
 
 It's important to have a contact form so that people know how to get in touch with your team.

--- a/pages/writing-content-for-your-federalist-homepage.md
+++ b/pages/writing-content-for-your-federalist-homepage.md
@@ -1,6 +1,6 @@
 ---
 permalink: /writing-content-for-your-federalist-homepage/
-title: Writing Content for Your Homepage
+title: Writing content for your homepage
 ---
 
 We have compiled a series of tips for writing different sections of your Federalist homepage. The homepage is partioned into four sections: mission statement, announcements, the carousel of facts, and a contact form. We explain what content goes in each section below.


### PR DESCRIPTION
When the page titles don't match the sidebar titles, the sidebar highlight doesn't work properly. This updates the page titles, rather than updating the existing `navigation:` property.

Also with this update, you now can access the site locally at http://localhost:4000/ instead of http://localhost:4000/federalist-content-guide/, but it will still appear at https://pages.18f.gov/federalist-content-guide/.

cc: @melodykramer 
